### PR TITLE
feat(homepage): display the search bar for mobile users

### DIFF
--- a/src/app/components/pages/HomePage/index.tsx
+++ b/src/app/components/pages/HomePage/index.tsx
@@ -1,11 +1,12 @@
 import { Theme, themesIcons } from '@/config';
 import { Service } from '@/types';
-import { Stack, Text } from '@mantine/core';
+import { Group, Stack, Text } from '@mantine/core';
 import { getTranslations } from 'next-intl/server';
 import { fetchServices } from '../../../../cms/utils';
 import ThemesBanner from '../../common/ThemesBanner';
 import ExamplesSection from './components/ExamplesSection';
 import ThemeSection from './components/ThemeSection';
+import SearchBar from '../../navigation/SearchBar';
 
 const fetchThemeServices = async ({ theme }: { theme: Theme }): Promise<Service[]> => {
   return (
@@ -30,6 +31,9 @@ const HomePage = async ({}: {}) => {
   );
   return (
     <Stack gap={'xl'} pt="xl">
+      <Group hiddenFrom='md' grow>
+        <SearchBar />
+      </Group>
       <ExamplesSection />
       <Text fz={{ base: '1.2rem', sm: '2rem' }} c="green_oryx" fw="bold">
         {t('explore_themes_label')}


### PR DESCRIPTION
La barre de recherche étant déjà présente sur la page `services`, ce commit l'ajoute seulement sur la page d'accueil