### PR TITLE
fix(cms): Fix CMS content title styling

### DIFF
--- a/src/app/components/content/utils-ui.tsx
+++ b/src/app/components/content/utils-ui.tsx
@@ -33,13 +33,21 @@ export const displayContentElementFromBlocks = (node: any, index: number): React
   const { type, children } = node;
   switch (type) {
     case 'heading':
+      let titleContent;
+
+      // Prevent title theme overrides from insered Span components
+      if (children.length === 1 && children[0].type === "text"){
+          titleContent = children[0].text
+      } else {
+          titleContent = children.map(displayContentElementFromBlocks)
+      }
       return (
         <Title
           key={index}
           order={node.level}
           fw={node.level === 1 ? 'bolder' : node.level === 2 ? 'bold' : node.level === 3 ? 'bold' : 'normal'}
           fz={node.level === 1 ? '1.6rem' : node.level === 2 ? '1.4rem' : node.level === 3 ? '1.2rem' : '1rem'}>
-          {children.map(displayContentElementFromBlocks)}
+          {titleContent}
         </Title>
       );
     case 'paragraph':


### PR DESCRIPTION
La fonction, via sa récursivité, ajoutait des `Span` (avec le style de texte) dans les balises titre.

Le `if` est là pour continuer de gérer le contenu dans le cas où le CMS retournerait qqch d'atypique