### PR TITLE
feat:le lien linkedIn a changé vers Oryxchange (nouveau)

### DIFF
--- a/src/app/components/navigation/items.ts
+++ b/src/app/components/navigation/items.ts
@@ -61,7 +61,7 @@ export const getFooterLinks = async () => {
       },
       {
         name: 'LinkedIn',
-        href: 'https://www.linkedin.com/company/pour-un-avenir-durable-en-occitanie/',
+        href: 'https://www.linkedin.com/company/oryxchange/posts/',
         isExternal: true
       }
     ],


### PR DESCRIPTION
La tâche "Footer : mettre le lien vers la page LinkedIn d’Oryxchange" sur la carte Trello a été refaite